### PR TITLE
Support error injection at arbitrary trace point

### DIFF
--- a/test/nemesis_SUITE.erl
+++ b/test/nemesis_SUITE.erl
@@ -50,7 +50,7 @@ t_recover(Config) when is_list(Config) ->
        ?inject_crash( #{kind := foo}
                     , snabbkaffe_nemesis:recover_after(N)
                     ),
-       [catch ?maybe_crash(foo, #{}) || _ <- lists:seq(1, 2*N)]
+       [catch ?maybe_crash(#{kind => foo}) || _ <- lists:seq(1, 2*N)]
      end,
      fun(_Result, Trace) ->
          ?assertEqual( N
@@ -67,3 +67,25 @@ t_periodic(Config) when is_list(Config) ->
   ?assertEqual( [true, true, false, false, false, true, true, false, false, false]
               , [F2(I) || I <- lists:seq(1, 10)]
               ).
+
+%% Check that error can be inhjectied at random trace point
+t_break_trace_point(Config) when is_list(Config) ->
+  N = 4,
+  ?check_trace(
+     begin
+       ?inject_crash( #{kind := foo}
+                    , snabbkaffe_nemesis:recover_after(N)
+                    ),
+       [catch ?tp(foo, #{}) || _ <- lists:seq(1, 2*N)]
+     end,
+     fun(_Result, Trace) ->
+         ?assertEqual( N
+                     , length(?of_kind(snabbkaffe_crash, Trace))
+                     )
+     end).
+
+%% Check that static unique tokens are indeed unique
+t_static_unique_points(Config) when is_list(Config) ->
+  A = ?__snkStaticUniqueToken,
+  B = ?__snkStaticUniqueToken,
+  ?assertEqual(false, A =:= B).


### PR DESCRIPTION
This PR makes it easier to write fault tolerance tests. Any trace point can be used to break the code.