### PR TITLE
Call to cast

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,9 @@ compile:
 .PHONY: concuerror_test
 concuerror_test: $(CONCUERROR)
 	rebar3 as concuerror eunit
-	$(CONCUERROR_RUN) -f $(BUILD_DIR)/concuerror+test/lib/snabbkaffe/test/concuerror_tests.beam  || \
+	$(CONCUERROR_RUN) -f $(BUILD_DIR)/concuerror+test/lib/snabbkaffe/test/concuerror_tests.beam -t race_test || \
+		{ cat concuerror_report.txt; exit 1; }
+	$(CONCUERROR_RUN) -f $(BUILD_DIR)/concuerror+test/lib/snabbkaffe/test/concuerror_tests.beam -t causality_test || \
 		{ cat concuerror_report.txt; exit 1; }
 
 $(CONCUERROR):


### PR DESCRIPTION
Using cast instead of call for emitting traces is very desirable, and it passes concuerror tests, but is potentially dangerous. I am seeking confirmation from the OTP team, that this change won't mess up causality.