### PR TITLE
Fix description how to run under concuerror

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 BUILD_DIR := $(CURDIR)/_build
 CONCUERROR := $(BUILD_DIR)/Concuerror/bin/concuerror
-CONCUERROR_RUN := $(CONCUERROR) -x code -x code_server -x error_handler --assertions_only \
+CONCUERROR_RUN := $(CONCUERROR) \
+	--treat_as_normal shutdown --treat_as_normal normal \
+	-x code -x code_server -x error_handler \
 	-pa $(BUILD_DIR)/concuerror+test/lib/snabbkaffe/ebin
 
 .PHONY: compile

--- a/README.org
+++ b/README.org
@@ -347,7 +347,9 @@ following code to the =rebar.config=:
 Run concuerror with the following flags:
 
 #+BEGIN_SRC bash
-$(CONCUERROR) --assertions_only --pa $(BUILD_DIR)/concuerror+test/lib/snabbkaffe/ebin
+$(CONCUERROR) --treat_as_normal shutdown --treat_as_normal normal \
+              -x code -x code_server -x error_handler \
+              --pa $(BUILD_DIR)/concuerror+test/lib/snabbkaffe/ebin
 #+END_SRC
 
 P.S. Again, this feature is experimental, use at your own risk.


### PR DESCRIPTION
Turns out --assertions-only flag passed to concuerror hides too many
errors and should be avoided